### PR TITLE
Add Property ID, Item_Relations ID, and Subject / Object ItemTitles

### DIFF
--- a/models/Api/ItemRelationsRelation.php
+++ b/models/Api/ItemRelationsRelation.php
@@ -12,17 +12,17 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
             $term = null;
         }
         $subject=get_record_by_id('item',$record->subject_item_id);
-		$object=get_record_by_id('item',$record->object_item_id);
-		
+        $object=get_record_by_id('item',$record->object_item_id);
+        
         return array(
             'subject' => array(
                 'id' => $record->subject_item_id,
                 'url' => self::getResourceUrl("/items/{$record->subject_item_id}"),
-				'label' => ItemRelationsPlugin::getItemTitle($subject),
+                'title' => ItemRelationsPlugin::getItemTitle($subject),
                 'resource' => 'items',
             ),
             'relation' => array(
-				'id' => $record->property_id,
+                'id' => $record->property_id,
                 'term' => $term,
                 'label' => $record->property_label,
                 'vocabulary' => $record->vocabulary_name,
@@ -30,13 +30,39 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
             'object' => array(
                 'id' => $record->object_item_id,
                 'url' => self::getResourceUrl("/items/{$record->object_item_id}"),
-				'label' => ItemRelationsPlugin::getItemTitle($object),
+                'title' => ItemRelationsPlugin::getItemTitle($object),
                 'resource' => 'items',
             ),
-			'item_relation' => array(
-				'id' => $record->id,
-				'resource' => 'item_relations',
-			),
+            'item_relation' => array(
+                'id' => $record->id,
+                'resource' => 'item_relations',
+            ),
         );
+        /*
+        return array(
+            'item_relation' => array(
+                'id' => $record->id,
+                'resource' => 'item_relations',
+                'subject' => array(
+                    'id' => $record->subject_item_id,
+                    'url' => self::getResourceUrl("/items/{$record->subject_item_id}"),
+                    'title' => ItemRelationsPlugin::getItemTitle($subject),
+                    'resource' => 'items',
+                ),
+                'relation' => array(
+                    'id' => $record->property_id,
+                    'term' => $term,
+                    'label' => $record->property_label,
+                    'vocabulary' => $record->vocabulary_name,
+                ),
+                'object' => array(
+                    'id' => $record->object_item_id,
+                    'url' => self::getResourceUrl("/items/{$record->object_item_id}"),
+                    'title' => ItemRelationsPlugin::getItemTitle($object),
+                    'resource' => 'items',
+                )
+            )
+        );
+        */
     }
 }

--- a/models/Api/ItemRelationsRelation.php
+++ b/models/Api/ItemRelationsRelation.php
@@ -15,6 +15,7 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
         $object=get_record_by_id('item',$record->object_item_id);
         
         return array(
+            'id' => $record->id,
             'subject' => array(
                 'id' => $record->subject_item_id,
                 'url' => self::getResourceUrl("/items/{$record->subject_item_id}"),
@@ -33,36 +34,6 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
                 'title' => ItemRelationsPlugin::getItemTitle($object),
                 'resource' => 'items',
             ),
-            'item_relation' => array(
-                'id' => $record->id,
-                'resource' => 'item_relations',
-            ),
         );
-        /*
-        return array(
-            'item_relation' => array(
-                'id' => $record->id,
-                'resource' => 'item_relations',
-                'subject' => array(
-                    'id' => $record->subject_item_id,
-                    'url' => self::getResourceUrl("/items/{$record->subject_item_id}"),
-                    'title' => ItemRelationsPlugin::getItemTitle($subject),
-                    'resource' => 'items',
-                ),
-                'relation' => array(
-                    'id' => $record->property_id,
-                    'term' => $term,
-                    'label' => $record->property_label,
-                    'vocabulary' => $record->vocabulary_name,
-                ),
-                'object' => array(
-                    'id' => $record->object_item_id,
-                    'url' => self::getResourceUrl("/items/{$record->object_item_id}"),
-                    'title' => ItemRelationsPlugin::getItemTitle($object),
-                    'resource' => 'items',
-                )
-            )
-        );
-        */
     }
 }

--- a/models/Api/ItemRelationsRelation.php
+++ b/models/Api/ItemRelationsRelation.php
@@ -11,13 +11,18 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
         if ($term == ':') {
             $term = null;
         }
+        $subject=get_record_by_id('item',$record->subject_item_id);
+		$object=get_record_by_id('item',$record->object_item_id);
+		
         return array(
             'subject' => array(
                 'id' => $record->subject_item_id,
                 'url' => self::getResourceUrl("/items/{$record->subject_item_id}"),
+				'label' => ItemRelationsPlugin::getItemTitle($subject),
                 'resource' => 'items',
             ),
             'relation' => array(
+				'id' => $record->property_id,
                 'term' => $term,
                 'label' => $record->property_label,
                 'vocabulary' => $record->vocabulary_name,
@@ -25,8 +30,13 @@ class Api_ItemRelationsRelation extends Omeka_Record_Api_AbstractRecordAdapter
             'object' => array(
                 'id' => $record->object_item_id,
                 'url' => self::getResourceUrl("/items/{$record->object_item_id}"),
+				'label' => ItemRelationsPlugin::getItemTitle($object),
                 'resource' => 'items',
             ),
+			'item_relation' => array(
+				'id' => $record->id,
+				'resource' => 'item_relations',
+			),
         );
     }
 }


### PR DESCRIPTION
Add Property ID, Item_Relations ID, and Subject / Object Item Titles to API JSON

Essentially these are named graphs, they should have the resource ID, as well as the property ID for the relation itself. If the relation has labels, so should the subject and object, for consistency